### PR TITLE
feat: Define `__init_subclass__` in `Serializer` for `Meta` validation

### DIFF
--- a/serializers/base_serializers.py
+++ b/serializers/base_serializers.py
@@ -1,0 +1,59 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional, TypeVar, Type, Protocol, Any
+
+T = TypeVar('T')
+
+class SerializerMeta(Protocol):
+    model: Any
+    fields: Optional[List[str]] = None
+    exclude: Optional[List[str]] = None
+
+class Serializer(ABC):
+    @classmethod
+    def __init_subclass__(cls, *args, **kwargs) -> None:
+        super().__init_subclass__(*args, **kwargs)
+        cls._validate_meta()
+
+    @classmethod
+    def _get_meta(cls) -> Type[SerializerMeta] | None:
+        return getattr(cls, 'Meta', None)
+
+    @classmethod
+    def _get_fields(cls) -> List[str]:
+        meta = cls._get_meta()
+        model = meta.model
+        assert model is not None
+
+        fields = getattr(meta, 'fields', None)
+        if fields:
+            return fields
+
+        fields = getattr(model, '__annotations__', {}).keys()
+        exclude = getattr(meta, 'exclude') or []
+
+        return [field for field in fields if field not in exclude]
+
+    @classmethod
+    def _validate_fields(cls, fields, model) -> None:
+        for field in fields:
+            if field not in model.__annotations__.keys():
+                raise ValueError(f"Attribute {field} does not exist on class {model.__name__!r}")
+
+    @classmethod
+    def _validate_meta(cls) -> None:
+        meta = cls._get_meta()
+
+        if meta is None or not hasattr(meta, 'model'):
+            raise ValueError(f"Serializer class must define a Meta class with a 'model' attribute")
+
+        cls._validate_fields(cls._get_fields(), meta.model)
+
+    @classmethod
+    @abstractmethod
+    def serialize(cls, instance: T) -> str:
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def deserialize(cls, data: str) -> T:
+        raise NotImplementedError


### PR DESCRIPTION
- Move `Meta` validation to `__init_subclass__` to enforce presence and compatibility on sub-class creation
- Keep `_validate_fields` separate (not merged into `_validate_meta`) to allow easier overrides for custom field validation logic